### PR TITLE
Fix atlas bleeding

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,8 @@
       "Bash(bun biome format:*)",
       "Bash(bun test:*)",
       "Bash(biome check:*)",
-      "Bash(bun run biome:check:*)"
+      "Bash(bun run biome:check:*)",
+      "Bash(ls -la /Users/neilsarkar/work/toodle/examples/*.ts)"
     ]
   }
 }

--- a/examples/21-atlas-artifact.ts
+++ b/examples/21-atlas-artifact.ts
@@ -1,0 +1,122 @@
+import { Toodle } from "../src/Toodle";
+import { createCanvas } from "./util";
+
+async function main() {
+	const toodle = await Toodle.attach(
+		createCanvas(window.innerWidth, window.innerHeight),
+		{
+			filter: 'linear'
+		}
+	);
+
+	await toodle.assets.registerBundle("train_day", {
+		atlases: [
+			{
+				json: new URL("stage_full_train_day-0.json", import.meta.url),
+				png: new URL("stage_full_train_day-0.png", import.meta.url),
+			},
+		],
+	});
+
+	const shader = toodle.QuadShader('bg paint', 2,
+		/*wgsl*/ `
+@fragment
+fn frag(vertex: VertexOutput) -> @location(0) vec4f {
+  let color = default_fragment_shader(vertex, linearSampler);
+
+	if (color.a == 0.0) {
+		return vec4f(0.5, 0.5, 0.5, 1.0);
+	}
+  return color;
+}
+  `)
+
+	const lightShader = toodle.QuadShader('light paint', 2,
+		/*wgsl*/ `
+@fragment
+fn frag(vertex: VertexOutput) -> @location(0) vec4f {
+	let color = default_fragment_shader(vertex, linearSampler);
+
+	// if (color.a < 0.7) {
+	// 	discard;
+	// }
+
+	// return vec4f(color.rgb, step(0.99, color.a));
+
+	return color;
+}`)
+
+
+	// toodle.clearColor = { r: 1, g: 0, b: 1, a: 1 };
+
+	const spriteId =
+		"stages/train_day/shc_train_daytime_main_tunnel_greenlight.png";
+
+	console.log(toodle.assets.bundles.textureIds);
+
+	// Let the engine derive cropOffset/region from the atlas naturally
+	const quad = toodle.Quad(spriteId, {
+		// size: {
+		// 	width: 3696.6000000000004,
+		// 	height: 1801.2368055555553,
+		// },
+		shader: lightShader,
+	});
+
+	quad.scale = 2;
+
+	console.log("quad size:", quad.size);
+	console.log("quad cropOffset:", quad.cropOffset);
+	console.log("quad region:", quad.region);
+
+	function frame() {
+		toodle.startFrame();
+		toodle.draw(toodle.Quad("stages/train_day/shc_train_daytime_test_main.png", {shader}))
+		toodle.draw(quad);
+
+		toodle.endFrame();
+		requestAnimationFrame(frame);
+	}
+	requestAnimationFrame(frame);
+
+	toodle.camera.x =
+1317.9858789909215;
+	toodle.camera.y =
+-464.02824201815724;
+	toodle.camera.zoom = 5.559917313492232;
+
+	window.addEventListener("keydown", (e) => {
+		switch (e.key) {
+			case "i":
+				toodle.camera.y += 100 / toodle.camera.zoom;
+				break;
+			case "k":
+				toodle.camera.y -= 100 / toodle.camera.zoom;
+				break;
+			case "j":
+				toodle.camera.x -= 100 / toodle.camera.zoom;
+				break;
+			case "l":
+				toodle.camera.x += 100 / toodle.camera.zoom;
+				break;
+			case "u":
+				toodle.camera.rotation -= 1;
+				break;
+			case "o":
+				toodle.camera.rotation += 1;
+				break;
+			case "-":
+				toodle.camera.zoom -= 0.1 * toodle.camera.zoom;
+				break;
+			case "=":
+				toodle.camera.zoom += 0.1 * toodle.camera.zoom;
+				break;
+			default: return;
+		}
+
+		console.log({camera: toodle.camera});
+	});
+}
+
+main();
+

--- a/src/textures/Bundles.ts
+++ b/src/textures/Bundles.ts
@@ -480,6 +480,11 @@ export class Bundles {
     const bottomCrop =
       frame.sourceSize.h - frame.spriteSourceSize.y - frame.spriteSourceSize.h;
 
+    // Inset UVs by half a texel to prevent bilinear sampling from
+    // bleeding into adjacent atlas padding/sprites
+    const halfTexelX = 0.5 / atlasWidth;
+    const halfTexelY = 0.5 / atlasHeight;
+
     return {
       cropOffset: {
         x: leftCrop - rightCrop,
@@ -490,16 +495,16 @@ export class Bundles {
         height: frame.sourceSize.h,
       },
       uvOffset: {
-        x: frame.frame.x / atlasWidth,
-        y: frame.frame.y / atlasHeight,
+        x: frame.frame.x / atlasWidth + halfTexelX,
+        y: frame.frame.y / atlasHeight + halfTexelY,
       },
       uvScale: {
         width: frame.sourceSize.w / atlasWidth,
         height: frame.sourceSize.h / atlasHeight,
       },
       uvScaleCropped: {
-        width: frame.frame.w / atlasWidth,
-        height: frame.frame.h / atlasHeight,
+        width: (frame.frame.w - 1) / atlasWidth,
+        height: (frame.frame.h - 1) / atlasHeight,
       },
     };
   }

--- a/src/textures/util.ts
+++ b/src/textures/util.ts
@@ -109,18 +109,22 @@ export async function packBitmapsToAtlas(
     }
 
     // Create atlas coords
+    // Inset UVs by half a texel to prevent bilinear sampling from
+    // bleeding into adjacent atlas padding/sprites
+    const halfTexel = 0.5 / textureSize;
+
     atlasRegionMap.set(id, {
       uvOffset: {
-        x: space.x / textureSize,
-        y: space.y / textureSize,
+        x: space.x / textureSize + halfTexel,
+        y: space.y / textureSize + halfTexel,
       },
       uvScale: {
         width: originalSize.width / textureSize,
         height: originalSize.height / textureSize,
       },
       uvScaleCropped: {
-        width: texture.width / textureSize,
-        height: texture.height / textureSize,
+        width: (texture.width - 1) / textureSize,
+        height: (texture.height - 1) / textureSize,
       },
       cropOffset: offset,
       originalSize,


### PR DESCRIPTION
Seeing some artifacts like this - padding is replaced by red pixels to make the effect more pronounced

<img width="763" height="575" alt="Toodle_🔇" src="https://github.com/user-attachments/assets/575801ea-77e2-40bd-8f53-04e8ef3351b1" />

Apparently the fix for this is either half texel insets on the uvs or extruding images in the atlas, and since we don't define the atlas generation pipelines, it seemed like half texel insets were the best option. Hopefully this won't mess with pixel art (the examples seem fine) but worth keeping an eye out